### PR TITLE
Improve starter fodder for linux

### DIFF
--- a/genes/dbosoft/starter-food/1.2/fodder/linux-starter.yaml
+++ b/genes/dbosoft/starter-food/1.2/fodder/linux-starter.yaml
@@ -1,0 +1,29 @@
+name: linux-starter
+
+variables:
+  - name: username
+    value: admin
+    required: true
+  - name: password
+    required: true
+    secret: true
+    value: admin
+  - name: lockPassword
+    type: boolean
+    value: false    
+  - name: sshPublicKey
+    required: false
+
+fodder:
+- name: admin-linux
+  type: cloud-config
+  secret: true
+  content: |
+    users:
+    - name: '{{ username }}'
+      plain_text_passwd: '{{ password }}'
+      groups: adm
+      lock_passwd: {{ lockPassword }}
+      sudo: 'ALL=(ALL) NOPASSWD: ALL'
+      ssh_authorized_keys:
+      - '{{ sshPublicKey }}'

--- a/genes/dbosoft/starter-food/1.2/fodder/win-starter.yaml
+++ b/genes/dbosoft/starter-food/1.2/fodder/win-starter.yaml
@@ -1,0 +1,49 @@
+name: win-starter
+
+variables:
+  - name: AdminUsername
+    value: Admin
+    required: true
+  - name: AdminPassword
+    required: true
+    secret: true
+    value: InitialPassw0rd
+
+fodder:
+- name: admin-windows
+  type: cloud-config
+  secure: true
+  content: |
+    users:
+      - name: '{{ AdminUsername }}'
+        groups: [ "Administrators" ]
+        passwd: '{{ AdminPassword }}'
+
+- name: remote-desktop
+  type: shellscript
+  fileName: enable_rd.ps1  #this is only required due to a bug in cloudbase-init
+  content: |
+    #ps1
+    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\" -Name "fDenyTSConnections" -Value 0
+    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\" -Name "UserAuthentication" -Value 1
+    Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+
+- name: ssh-server
+  type: shellscript
+  fileName: enable_sshd.ps1  #this is only required due to a bug in cloudbase-init
+  content: |
+    Get-WindowsCapability -Online | Where-Object Name -like 'OpenSSH.Server*' | Add-WindowsCapability -Online
+    
+    # Start the sshd service
+    Start-Service sshd
+
+    # OPTIONAL but recommended:
+    Set-Service -Name sshd -StartupType 'Automatic'
+
+    # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
+    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
+      Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
+      New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+    } else {
+      Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+    }

--- a/genes/dbosoft/starter-food/1.2/geneset-tag.json
+++ b/genes/dbosoft/starter-food/1.2/geneset-tag.json
@@ -1,0 +1,1 @@
+{"version":"1.0","geneset":"dbosoft/starter-food/1.2"}

--- a/genes/dbosoft/starter-food/latest/geneset-tag.json
+++ b/genes/dbosoft/starter-food/latest/geneset-tag.json
@@ -1,1 +1,1 @@
-{"version":"1.0","geneset":"dbosoft/starter-food/latest","ref":"dbosoft/starter-food/1.1"}
+{"version":"1.0","geneset":"dbosoft/starter-food/latest","ref":"dbosoft/starter-food/1.2"}


### PR DESCRIPTION
This PR improves the starter fodder for linux:
- Use single quotes around variables. This prevents schema issues when no SSH key is specified.
- Correct the incorrect group specification and add the user to the group `adm` which grants log file access on Ubuntu.