### PR TITLE
windows - rdp and ssdh script errors

### DIFF
--- a/.changeset/sharp-terms-learn.md
+++ b/.changeset/sharp-terms-learn.md
@@ -1,0 +1,8 @@
+---
+"@dbosoft/starter-food-default": minor
+---
+
+windows - rdp and ssdh script errors
+
+RDP script fails due to formatting (see #2)
+SSHD script fails on Windows Server 2016 (where it is not supported) 

--- a/src/starter-food/default/fodder/linux-starter.yaml
+++ b/src/starter-food/default/fodder/linux-starter.yaml
@@ -1,0 +1,30 @@
+ 
+name: linux-starter
+
+variables:
+  - name: username
+    value: admin
+    required: true
+  - name: password
+    required: true
+    secret: true
+    value: admin
+  - name: lockPassword
+    type: boolean
+    value: false    
+  - name: sshPublicKey
+    required: false
+
+fodder:
+- name: admin-linux
+  type: cloud-config
+  secret: true
+  content: |
+    users:
+    - name: {{ username }}
+      plain_text_passwd: {{ password }}
+      group: admin
+      lock_passwd: {{ lockPassword }}
+      sudo: 'ALL=(ALL) NOPASSWD: ALL'
+      ssh_authorized_keys:
+      - {{ sshPublicKey }}

--- a/src/starter-food/default/fodder/win-starter.yaml
+++ b/src/starter-food/default/fodder/win-starter.yaml
@@ -1,0 +1,60 @@
+name: win-starter
+
+variables:
+  - name: AdminUsername
+    value: Admin
+    required: true
+  - name: AdminPassword
+    required: true
+    secret: true
+    value: InitialPassw0rd
+
+fodder:
+- name: admin-windows
+  type: cloud-config
+  secret: true
+  content: |
+    users:
+      - name: {{ AdminUsername }}
+        groups: [ "Administrators" ]
+        passwd: {{ AdminPassword }}
+
+- name: remote-desktop
+  type: shellscript
+  fileName: enable_rd.ps1  #this is only required due to a bug in cloudbase-init
+  content: |
+    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\" -Name "fDenyTSConnections" -Value 0
+    Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\" -Name "UserAuthentication" -Value 1
+    Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
+
+- name: ssh-server
+  type: shellscript
+  fileName: enable_sshd.ps1  #this is only required due to a bug in cloudbase-init
+  content: |
+    $cap = Get-WindowsCapability -Online | Where-Object Name -like 'OpenSSH.Server*'
+    if(-not $cap){
+      Write-Output "OpenSSH Server capability not found. No SSH Server will be installed."
+      exit 0
+    }
+    
+    $cap | Add-WindowsCapability -Online
+    
+    # make sure the sshd service is exists.
+    if (!(Get-Service sshd -ErrorAction SilentlyContinue)) {
+      Write-Output "sshd service does not exist, you may have to install OpenSSH manually."
+      exit -1
+    }
+
+    # Start the sshd service
+    Start-Service sshd
+
+    # OPTIONAL but recommended:
+    Set-Service -Name sshd -StartupType 'Automatic'
+
+    # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
+    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
+      Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
+      New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+    } else {
+      Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+    }


### PR DESCRIPTION
RDP script fails due to formatting (see #2)
SSHD script fails on Windows Server 2016 (where it is not supported) 