### PR TITLE
Fix SSH firewall rule for Windows Server 2025

### DIFF
--- a/.changeset/large-aliens-follow.md
+++ b/.changeset/large-aliens-follow.md
@@ -1,0 +1,8 @@
+---
+"@dbosoft/starter-food-default": minor
+---
+
+Fix SSH firewall rule for Windows Server 2025
+
+By default, Windows Server 2025 opens the port for OpenSSH only for the private network profile.
+This change ensures that the firewall rule is always applied to all network profiles.

--- a/src/starter-food/default/fodder/win-starter.yaml
+++ b/src/starter-food/default/fodder/win-starter.yaml
@@ -37,7 +37,7 @@ fodder:
       exit 0
     }
     
-    $cap | Add-WindowsCapability -Online
+    $null = $cap | Add-WindowsCapability -Online
     
     # make sure the sshd service is exists.
     if (!(Get-Service sshd -ErrorAction SilentlyContinue)) {
@@ -57,4 +57,6 @@ fodder:
       New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
     } else {
       Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+      # Enable for all network profiles. Windows Server 2025 only allows private networks by default.
+      Set-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -Profile 'Any'
     }


### PR DESCRIPTION
This PR improves the starter food for Windows such that the port for SSH is correctly opened on Windows Server 2025.