### PR TITLE
guest-services: add genes for installation

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,6 +40,25 @@ importers:
 
   packages/templates: {}
 
+  src/guest-services:
+    dependencies:
+      '@dbosoft/guest-services-default':
+        specifier: workspace:*
+        version: link:default
+      templates:
+        specifier: workspace:*
+        version: link:../../packages/templates
+    devDependencies:
+      '@dbosoft/build-geneset':
+        specifier: workspace:*
+        version: link:../../packages/build-geneset
+
+  src/guest-services/default:
+    devDependencies:
+      '@dbosoft/build-geneset':
+        specifier: workspace:*
+        version: link:../../../packages/build-geneset
+
   src/hyperv:
     dependencies:
       '@dbosoft/hyperv-default':

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -65,7 +65,7 @@ fodder:
 
           [Service]
           Type=notify
-          ExecStart=/opt/eryph/guest-services/egs-service
+          ExecStart=/opt/eryph/guest-services/bin/egs-service
 
           [Install]
           WantedBy=multi-user.target

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -7,23 +7,16 @@ variables:
     required: true
 
 fodder:
-- name: install-packages
-  type: cloud-config
-  content:
-    packages:
-    - dotnet-runtime-8.0
-    - unzip
-
 - name: install-egs
   type: shellscript
   content: |
     #!/usr/bin/env bash
     set -euo pipefail
-    wget -O egs-linux.zip '{{ downloadUrl }}'
+    wget -O egs-linux.tar.gz '{{ downloadUrl }}'
 
     mkdir -p /opt/eryph/guest-services
-    unzip egs-linux.zip -d /opt/eryph/guest-services
-    rm egs-linux.zip
+    tar -xf egs-linux.tar.gz -C /opt/eryph/guest-services
+    rm egs-linux.tar.gz
     chmod +x /opt/eryph/guest-services/egs
 
 - name: write-files

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -1,8 +1,10 @@
 name: linux-install
 
 variables:
-  - name: downloadUrl
+  - name: version
+    value: latest
     required: true
+  - name: downloadUrl
   - name: sshPublicKey
     required: true
 
@@ -10,15 +12,48 @@ fodder:
 - name: install-egs
   type: shellscript
   content: |
-    #!/usr/bin/env bash
-    set -euo pipefail
-    wget -O egs-linux.tar.gz '{{ downloadUrl }}'
+    #!/usr/bin/env python3
+    import json
+    import os
+    import re
+    import subprocess
+    import urllib.request
+    import tarfile
 
-    mkdir -p /opt/eryph/guest-services
-    tar -xf egs-linux.tar.gz -C /opt/eryph/guest-services
-    rm egs-linux.tar.gz
-    chmod +x /opt/eryph/guest-services/egs
+    download_url = '{{ downloadUrl }}'
+    if not download_url:
+      requested_version = '{{ version }}'
+      version = requested_version
+      with urllib.request.urlopen('https://releases.dbosoft.eu/eryph/guest-services/index.json') as response:
+        response_json = response.read().decode('utf-8')
+        product_info = json.loads(response_json)
+        if version == 'latest':
+          version = product_info.get('stableVersion')
+          if not version:
+            version = product_info['latestVersion']
 
+        if version == 'prerelease':
+          version = product_info['latestVersion']
+        
+        version_info = product_info['versions'].get(version)
+        if not version_info:
+          raise Exception(f"Version {requested_version} does not exist")
+
+        file_info = next(f for f in version_info['files'] if f['filename'].startswith('egs_') and f['os'] == 'linux' and f['arch'] == 'amd64')
+        download_url = file_info['url']
+    
+    urllib.request.urlretrieve(download_url, 'egs-linux.tar.gz')
+    
+    install_path = '/opt/eryph/guest-services'
+
+    os.makedirs(install_path, exist_ok=True)
+    with tarfile.open('egs-linux.tar.gz', 'r:gz') as tar:
+      tar.extractall(path=install_path)
+    os.remove('egs-linux.tar.gz')
+
+    # egs_service_path = os.path.join(install_path, 'egs-service')
+    # os.chmod(os.path.join(install_path, 'egs-service'), 0o755)
+    
 - name: write-files
   type: cloud-config
   content:
@@ -30,11 +65,11 @@ fodder:
 
           [Service]
           Type=notify
-          ExecStart=/opt/eryph/guest-services/egs
+          ExecStart=/opt/eryph/guest-services/egs-service
 
           [Install]
           WantedBy=multi-user.target
-      - path: /etc/opt/eryph/guest-services/egs.pub
+      - path: /etc/opt/eryph/guest-services/id_egs.pub
         content: '{{ sshPublicKey }}'
 
 - name: enable-systemd-unit

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -14,13 +14,6 @@ fodder:
     - dotnet-runtime-8.0
     - unzip
 
-- name: write-ssh-key
-  type: cloud-config
-  content:
-    write_files:
-      - path: /opt/etc/eryph/guest-services/egs.pub
-        content: '{{ sshPublicKey }}'
-
 - name: install-egs
   type: shellscript
   content: |
@@ -33,7 +26,7 @@ fodder:
     rm egs-linux.zip
     chmod +x /opt/eryph/guest-services/egs
 
-- name: add-systemd-unit
+- name: write-files
   type: cloud-config
   content:
     write_files:
@@ -48,6 +41,8 @@ fodder:
 
           [Install]
           WantedBy=multi-user.target
+      - path: /etc/opt/eryph/guest-services/egs.pub
+        content: '{{ sshPublicKey }}'
 
 - name: enable-systemd-unit
   type: shellscript

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -50,9 +50,6 @@ fodder:
     with tarfile.open('egs-linux.tar.gz', 'r:gz') as tar:
       tar.extractall(path=install_path)
     os.remove('egs-linux.tar.gz')
-
-    # egs_service_path = os.path.join(install_path, 'egs-service')
-    # os.chmod(os.path.join(install_path, 'egs-service'), 0o755)
     
 - name: write-files
   type: cloud-config
@@ -67,6 +64,8 @@ fodder:
           Type=notify
           ExecStart=/opt/eryph/guest-services/bin/egs-service
           Environment="HOME=/root"
+          Restart=on-failure
+          RestartSec=10
 
           [Install]
           WantedBy=multi-user.target

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -66,6 +66,7 @@ fodder:
           [Service]
           Type=notify
           ExecStart=/opt/eryph/guest-services/bin/egs-service
+          Environment="HOME=/root"
 
           [Install]
           WantedBy=multi-user.target

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -1,0 +1,59 @@
+name: linux-install
+
+variables:
+  - name: downloadUrl
+    required: true
+  - name: sshPublicKey
+    required: true
+
+fodder:
+- name: install-packages
+  type: cloud-config
+  content:
+    packages:
+    - dotnet-runtime-8.0
+    - unzip
+
+- name: write-ssh-key
+  type: cloud-config
+  content:
+    write_files:
+      - path: /opt/etc/eryph/guest-services/egs.pub
+        content: '{{ sshPublicKey }}'
+
+- name: install-egs
+  type: shellscript
+  content: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    wget -O egs-linux.zip '{{ downloadUrl }}'
+
+    mkdir -p /opt/eryph/guest-services
+    unzip egs-linux.zip -d /opt/eryph/guest-services
+    rm egs-linux.zip
+    chmod +x /opt/eryph/guest-services/egs
+
+- name: add-systemd-unit
+  type: cloud-config
+  content:
+    write_files:
+      - path: /etc/systemd/system/eryph-guest-services.service
+        content: |
+          [Unit]
+          Description=eryph guest services
+
+          [Service]
+          Type=notify
+          ExecStart=/opt/eryph/guest-services/egs
+
+          [Install]
+          WantedBy=multi-user.target
+
+- name: enable-systemd-unit
+  type: shellscript
+  content: |
+    #!/usr/bin/env bash
+    set -euo pipefail
+    systemctl daemon-reload
+    systemctl enable eryph-guest-services.service
+    systemctl start eryph-guest-services.service

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -63,4 +63,5 @@ fodder:
     Remove-Item -Path C:\egs-windows.zip
 
     sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\bin\egs-service.exe"
+    sc.exe failure eryph-guest-services reset=60 actions=restart/10000
     sc.exe start eryph-guest-services

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -1,8 +1,10 @@
 name: win-install
 
 variables:
-  - name: downloadUrl
+  - name: version
+    value: latest
     required: true
+  - name: downloadUrl
   - name: sshPublicKey
     required: true
 
@@ -11,7 +13,7 @@ fodder:
   type: cloud-config
   content:
     write_files:
-      - path: C:\ProgramData\eryph\guest-services\egs.pub
+      - path: C:\ProgramData\eryph\guest-services\id_egs.pub
         content: '{{ sshPublicKey }}'
 
 - name: install-egs
@@ -21,25 +23,44 @@ fodder:
     #ps1_sysnative
     $ErrorActionPreference = 'Stop'
     Set-StrictMode -Version 3.0
-    $ProgressPreference = 'SilentlyContinue'
+    # Expand-Archive is a script module and will take its preferences from the global scope.
+    # See https://github.com/PowerShell/Microsoft.PowerShell.Archive/issues/77#issuecomment-601947496
+    $global:ProgressPreference = 'SilentlyContinue'
 
     if ([System.Net.ServicePointManager]::SecurityProtocol -ne 0) {
       [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
     }
 
-    # Invoke-WebRequest -Uri "https://aka.ms/dotnet/8.0/dotnet-runtime-win-x64.exe" -OutFile C:\dotnet-runtime-win-x64.exe -UseBasicParsing
-    # $process = Start-Process -FilePath 'C:\dotnet-runtime-win-x64.exe' -ArgumentList "/install /quiet /norestart" -Wait -PassThru
+    $downloadUrl = '{{ downloadUrl }}'
+    if (-not $downloadUrl) {
+      $productInfo = Invoke-RestMethod -Uri 'https://releases.dbosoft.eu/eryph/guest-services/index.json' -UseBasicParsing
+      $requestedVersion = '{{ version }}'
+      $version = $requestedVersion
+      
+      if ($version -eq 'latest') {
+        $version = & { Set-StrictMode -Off; $productInfo.stableVersion }
+        if (-not $version) {
+          $version = $productInfo.latestVersion
+        }
+      }
 
-    # Remove-Item -Path C:\dotnet-runtime.msi
+      if ($version -eq 'prerelease') {
+        $version = $productInfo.latestVersion
+      }
 
-    # if ($process.ExitCode -ne 0 -and $process.ExitCode -ne 3010) {
-    #   throw "dotnet-runtime-win-x64.exe failed with exit code $($process.ExitCode)"
-    # }
+      $versionInfo = & { Set-StrictMode -Off; $productInfo.versions.$version }
+      if (-not $versionInfo) {
+        throw "Version '$requestedVersion' does not exist"
+      }
 
-    Invoke-WebRequest -Uri "{{ downloadUrl }}" -OutFile C:\egs-windows.zip -UseBasicParsing
+      $fileInfo = $versionInfo.files | Where-Object filename -like 'egs_*' -and os -eq 'windows' -and arch -eq 'amd64' | Select-Object -First 1
+      $downloadUrl = $fileInfo.url
+    }
+
+    Invoke-WebRequest -Uri $downloadUrl -OutFile C:\egs-windows.zip -UseBasicParsing
 
     Expand-Archive -Path C:\egs-windows.zip -DestinationPath "C:\Program Files\eryph\guest-services"
     Remove-Item -Path C:\egs-windows.zip
 
-    sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\egs.exe"
+    sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\egs-service.exe"
     sc.exe start eryph-guest-services

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -62,5 +62,5 @@ fodder:
     Expand-Archive -Path C:\egs-windows.zip -DestinationPath "C:\Program Files\eryph\guest-services"
     Remove-Item -Path C:\egs-windows.zip
 
-    sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\egs-service.exe"
+    sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\bin\egs-service.exe"
     sc.exe start eryph-guest-services

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -1,0 +1,45 @@
+name: win-install
+
+variables:
+  - name: downloadUrl
+    required: true
+  - name: sshPublicKey
+    required: true
+
+fodder:
+- name: write-ssh-key
+  type: cloud-config
+  content:
+    write_files:
+      - path: C:\ProgramData\eryph\guest-services\egs.pub
+        content: '{{ sshPublicKey }}'
+
+- name: install-egs
+  type: shellscript
+  fileName: Install-Egs.ps1
+  content: |
+    #ps1_sysnative
+    $ErrorActionPreference = 'Stop'
+    Set-StrictMode -Version 3.0
+    $ProgressPreference = 'SilentlyContinue'
+
+    if ([System.Net.ServicePointManager]::SecurityProtocol -ne 0) {
+      [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+    }
+
+    # Invoke-WebRequest -Uri "https://aka.ms/dotnet/8.0/dotnet-runtime-win-x64.exe" -OutFile C:\dotnet-runtime-win-x64.exe -UseBasicParsing
+    # $process = Start-Process -FilePath 'C:\dotnet-runtime-win-x64.exe' -ArgumentList "/install /quiet /norestart" -Wait -PassThru
+
+    # Remove-Item -Path C:\dotnet-runtime.msi
+
+    # if ($process.ExitCode -ne 0 -and $process.ExitCode -ne 3010) {
+    #   throw "dotnet-runtime-win-x64.exe failed with exit code $($process.ExitCode)"
+    # }
+
+    Invoke-WebRequest -Uri "{{ downloadUrl }}" -OutFile C:\egs-windows.zip -UseBasicParsing
+
+    Expand-Archive -Path C:\egs-windows.zip -DestinationPath "C:\Program Files\eryph\guest-services"
+    Remove-Item -Path C:\egs-windows.zip
+
+    sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\egs.exe"
+    sc.exe start eryph-guest-services

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -53,7 +53,7 @@ fodder:
         throw "Version '$requestedVersion' does not exist"
       }
 
-      $fileInfo = $versionInfo.files | Where-Object filename -like 'egs_*' -and os -eq 'windows' -and arch -eq 'amd64' | Select-Object -First 1
+      $fileInfo = $versionInfo.files | Where-Object { $_.filename -like 'egs_*' -and $_.os -eq 'windows' -and $_.arch -eq 'amd64' } | Select-Object -First 1
       $downloadUrl = $fileInfo.url
     }
 

--- a/src/guest-services/default/geneset-tag.json
+++ b/src/guest-services/default/geneset-tag.json
@@ -1,0 +1,1 @@
+{"version":"1.0","geneset":"dbosoft/guest-services/{{packageVersion.majorMinor}}"}

--- a/src/guest-services/default/package.json
+++ b/src/guest-services/default/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@dbosoft/guest-services-default",
   "private": true,
-  "version": "1.0.0",
+  "version": "0.1.0",
   "scripts": {
     "build": "build-geneset-tag",
     "publish": "build-geneset-tag publish"

--- a/src/guest-services/default/package.json
+++ b/src/guest-services/default/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@dbosoft/guest-services-default",
+  "private": true,
+  "version": "1.0.0",
+  "scripts": {
+    "build": "build-geneset-tag",
+    "publish": "build-geneset-tag publish"
+  },
+  "devDependencies": {
+    "@dbosoft/build-geneset": "workspace:*"
+  }
+}

--- a/src/guest-services/geneset.json
+++ b/src/guest-services/geneset.json
@@ -1,0 +1,8 @@
+{
+    "geneset": "dbosoft/guest-services",
+    "public": true,
+    "short_description": "Eryph Guest Services",
+    "description": "This geneset contains fodder for installing the eryph guest services.",
+    "description_markdown": null,
+    "description_markdown_file": "readme.md"
+}

--- a/src/guest-services/package.json
+++ b/src/guest-services/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "@dbosoft/guest-services",
+  "private": true,
+  "scripts": {
+    "build": "build-geneset",
+    "publish": "build-geneset publish"
+  },
+  "dependencies": {
+    "templates": "workspace:*",
+    "@dbosoft/guest-services-default": "workspace:*"
+  },
+  "devDependencies": {
+    "@dbosoft/build-geneset": "workspace:*"
+  }
+}

--- a/src/guest-services/readme.md
+++ b/src/guest-services/readme.md
@@ -1,0 +1,41 @@
+# Eryph Guest Services
+
+This geneset contains fodder for installing the erpyh guest services.
+
+## Usage
+
+To install the eryph guest services in your Windows catlets add a gene reference to the Windows gene:
+
+``` yaml
+fodder:
+ - source: gene:dbosoft/guest-services:win-install
+```
+
+or for Linux:
+
+
+``` yaml
+fodder:
+ - source: gene:dbosoft/guest-services:linux-install
+```
+
+## Configuration
+
+The Windows and the Linux gene support the same variables. The following variables can be used to configure the gene:
+
+- **downloadUrl**
+
+  The download URL from which the eryph guest services should be downloaded.
+
+- **sshPublicKey**
+  
+  The SSH public which should be used to authenticate connections to the eryph guest service. This public key
+  will be injected into the catlet. The public key for the eryph guest services is configured independently
+  of the atuhorized keys for the normal SSH server.
+
+---
+
+{{> food_versioning_major_minor }}
+
+{{> footer }}
+

--- a/src/guest-services/readme.md
+++ b/src/guest-services/readme.md
@@ -23,9 +23,16 @@ fodder:
 
 The Windows and the Linux gene support the same variables. The following variables can be used to configure the gene:
 
+- **version**  
+  default value: `latest`
+
+  The version of the eryph guest services which should be installed. The exact version, e.g. `0.1.0`, must
+  be provided. `latest` will install the latest released version. `prerelease` will install the latest
+  prerelease version.
+
 - **downloadUrl**
 
-  The download URL from which the eryph guest services should be downloaded.
+  When provided, the eryph guest services will be downloaded from this URL instead of looking up the version.
 
 - **sshPublicKey**
   

--- a/src/guest-services/readme.md
+++ b/src/guest-services/readme.md
@@ -13,7 +13,6 @@ fodder:
 
 or for Linux:
 
-
 ``` yaml
 fodder:
  - source: gene:dbosoft/guest-services:linux-install


### PR DESCRIPTION
This PR adds genes to install and configure the eryph guest services in Windows and Linux catlets.