### PR TITLE
Move SSH server configuration in Windows to dedicated gene

### DIFF
--- a/.changeset/ten-showers-study.md
+++ b/.changeset/ten-showers-study.md
@@ -1,0 +1,6 @@
+---
+"@dbosoft/starter-food-default": major
+"@dbosoft/winconfig-default": minor
+---
+
+Move configuration of SSH server feature in Windows to separate gene

--- a/genes/dbosoft/winconfig/readme.md
+++ b/genes/dbosoft/winconfig/readme.md
@@ -19,6 +19,14 @@ The fodder will automatically reboot the catlet after joining the domain.
   password of the domain admin user
 
 
+### enable-ssh
+
+With the fodder enable-ssh, you can enable the SSH server feature in Windows.
+This gene requires Windows Server 2019 (or Windows 10 1809) or newer. The
+corresponding Windows feature does not exist in older versions of Windows.
+
+
+---
 
 
 # Versioning

--- a/src/starter-food/default/fodder/win-starter.yaml
+++ b/src/starter-food/default/fodder/win-starter.yaml
@@ -26,37 +26,3 @@ fodder:
     Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\" -Name "fDenyTSConnections" -Value 0
     Set-ItemProperty "HKLM:\SYSTEM\CurrentControlSet\Control\Terminal Server\WinStations\RDP-Tcp\" -Name "UserAuthentication" -Value 1
     Enable-NetFirewallRule -DisplayGroup "Remote Desktop"
-
-- name: ssh-server
-  type: shellscript
-  fileName: enable_sshd.ps1  #this is only required due to a bug in cloudbase-init
-  content: |
-    $cap = Get-WindowsCapability -Online | Where-Object Name -like 'OpenSSH.Server*'
-    if(-not $cap){
-      Write-Output "OpenSSH Server capability not found. No SSH Server will be installed."
-      exit 0
-    }
-    
-    $null = $cap | Add-WindowsCapability -Online
-    
-    # make sure the sshd service is exists.
-    if (!(Get-Service sshd -ErrorAction SilentlyContinue)) {
-      Write-Output "sshd service does not exist, you may have to install OpenSSH manually."
-      exit -1
-    }
-
-    # Start the sshd service
-    Start-Service sshd
-
-    # OPTIONAL but recommended:
-    Set-Service -Name sshd -StartupType 'Automatic'
-
-    # Confirm the Firewall rule is configured. It should be created automatically by setup. Run the following to verify
-    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue | Select-Object Name, Enabled)) {
-      Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
-      New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
-    } else {
-      Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
-      # Enable for all network profiles. Windows Server 2025 only allows private networks by default.
-      Set-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -Profile 'Any'
-    }

--- a/src/winconfig/default/fodder/enable-ssh.yaml
+++ b/src/winconfig/default/fodder/enable-ssh.yaml
@@ -1,0 +1,41 @@
+name: enable-ssh
+
+fodder:
+- name: ssh-server
+  type: shellscript
+  fileName: enable_sshd.ps1
+  content: |
+    #ps1_sysnative
+    $ErrorActionPreference = 'Stop'
+
+    if ([System.Environment]::OSVersion.Version -lt 17763) {
+      Write-Output "OpenSSH Server capability only exists in Windows 1809 or newer."
+      exit -1
+    }
+    
+    $null = Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0
+    
+    # Make sure the sshd service exists
+    if (!(Get-Service sshd -ErrorAction SilentlyContinue)) {
+      Write-Output "sshd service does not exist, you may have to install OpenSSH manually."
+      exit -1
+    }
+
+    # Start the sshd service
+    Start-Service sshd
+    Set-Service -Name sshd -StartupType 'Automatic'
+
+    # Confirm the Firewall rule is configured. It should be created automatically by the setup.
+    if (!(Get-NetFirewallRule -Name "OpenSSH-Server-In-TCP" -ErrorAction SilentlyContinue)) {
+      Write-Output "Firewall Rule 'OpenSSH-Server-In-TCP' does not exist, creating it..."
+      
+      New-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -DisplayName 'OpenSSH Server (sshd)' -Enabled True -Direction Inbound -Protocol TCP -Action Allow -LocalPort 22
+    } else {
+      Write-Output "Firewall rule 'OpenSSH-Server-In-TCP' has been created and exists."
+      
+      # Enable for all network profiles. Windows Server 2025 only allows private networks by default.
+      Set-NetFirewallRule -Name 'OpenSSH-Server-In-TCP' -Profile 'Any'
+      
+      # Explicitly enable the firewall rule just in case
+      Enable-NetFirewallRule -Name 'OpenSSH-Server-In-TCP'
+    }

--- a/src/winconfig/default/fodder/enable-ssh.yaml
+++ b/src/winconfig/default/fodder/enable-ssh.yaml
@@ -8,7 +8,7 @@ fodder:
     #ps1_sysnative
     $ErrorActionPreference = 'Stop'
 
-    if ([System.Environment]::OSVersion.Version -lt 17763) {
+    if ([System.Environment]::OSVersion.Version.Build -lt 17763) {
       Write-Output "OpenSSH Server capability only exists in Windows 1809 or newer."
       exit -1
     }

--- a/src/winconfig/readme.md
+++ b/src/winconfig/readme.md
@@ -21,10 +21,12 @@ The fodder will automatically reboot the catlet after joining the domain.
 
 ### enable-ssh
 
-With the fodder enable-ssh, you can enable SSH server feature in Windows.
+With the fodder enable-ssh, you can enable the SSH server feature in Windows.
 This gene requires Windows Server 2019 (or Windows 10 1809) or newer. The
 corresponding Windows feature does not exist in older versions of Windows.
 
+
+---
 
 {{> food_versioning_major_minor }}
 

--- a/src/winconfig/readme.md
+++ b/src/winconfig/readme.md
@@ -19,6 +19,12 @@ The fodder will automatically reboot the catlet after joining the domain.
   password of the domain admin user
 
 
+### enable-ssh
+
+With the fodder enable-ssh, you can enable SSH server feature in Windows.
+This gene requires Windows Server 2019 (or Windows 10 1809) or newer. The
+corresponding Windows feature does not exist in older versions of Windows.
+
 
 {{> food_versioning_major_minor }}
 


### PR DESCRIPTION
This PR moves the SSH server configuration in Windows from the starter food to a dedicated gene. This improves the startup
time of Windows catlets with the starter food as the installation of the corresponding Windows feature can take some time.