### PR TITLE
guest-services: improvements

### DIFF
--- a/.changeset/sad-things-tell.md
+++ b/.changeset/sad-things-tell.md
@@ -1,0 +1,10 @@
+---
+"@dbosoft/guest-services-default": minor
+---
+
+Multiple minor improvements:
+
+- SSH public key is now optional to allow configuration with egs-tool instead
+- The TERM variable is set to a reasonable value on Linux to prevent CLI
+  tools from failing
+- The Windows guest service has auto start enabled by default

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -6,7 +6,6 @@ variables:
     required: true
   - name: downloadUrl
   - name: sshPublicKey
-    required: true
 
 fodder:
 - name: install-egs

--- a/src/guest-services/default/fodder/linux-install.yaml
+++ b/src/guest-services/default/fodder/linux-install.yaml
@@ -70,6 +70,7 @@ fodder:
           Type=notify
           ExecStart=/opt/eryph/guest-services/bin/egs-service
           Environment="HOME=/root"
+          Environment="TERM=xterm"
           Restart=on-failure
           RestartSec=10
 

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -6,7 +6,6 @@ variables:
     required: true
   - name: downloadUrl
   - name: sshPublicKey
-    required: true
 
 fodder:
 - name: write-ssh-key

--- a/src/guest-services/default/fodder/win-install.yaml
+++ b/src/guest-services/default/fodder/win-install.yaml
@@ -67,6 +67,6 @@ fodder:
     Expand-Archive -Path C:\egs-windows.zip -DestinationPath "C:\Program Files\eryph\guest-services"
     Remove-Item -Path C:\egs-windows.zip
 
-    sc.exe create eryph-guest-services binpath="C:\Program Files\eryph\guest-services\bin\egs-service.exe"
+    sc.exe create eryph-guest-services start=auto binpath="C:\Program Files\eryph\guest-services\bin\egs-service.exe"
     sc.exe failure eryph-guest-services reset=60 actions=restart/10000
     sc.exe start eryph-guest-services

--- a/src/guest-services/readme.md
+++ b/src/guest-services/readme.md
@@ -41,7 +41,7 @@ The Windows and the Linux gene support the same variables. The following variabl
 
   This variable is optional but you have to either specify an SSH public key here or invoke `egs-tool add-ssh-config`
   after the catlet has been created. Otherwise, no public key is available for authentication and the connection
-  to the catlet wail fail.
+  to the catlet will fail.
 
 
 ---

--- a/src/guest-services/readme.md
+++ b/src/guest-services/readme.md
@@ -37,7 +37,12 @@ The Windows and the Linux gene support the same variables. The following variabl
   
   The SSH public which should be used to authenticate connections to the eryph guest service. This public key
   will be injected into the catlet. The public key for the eryph guest services is configured independently
-  of the atuhorized keys for the normal SSH server.
+  of the authorized keys for the normal SSH server.
+
+  This variable is optional but you have to either specify an SSH public key here or invoke `egs-tool add-ssh-config`
+  after the catlet has been created. Otherwise, no public key is available for authentication and the connection
+  to the catlet wail fail.
+
 
 ---
 


### PR DESCRIPTION
This PR contains several small improvements:

- SSH public key is now optional to allow configuration with egs-tool instead
- The TERM variable is set to a reasonable value on Linux to prevent CLI tools from failing
- The Windows guest service has auto start enabled by default